### PR TITLE
Hide hidden sources on list page dropdown

### DIFF
--- a/lib/Catalyst/Plugin/AutoCRUD/templates/full-fat/wrapper.tt
+++ b/lib/Catalyst/Plugin/AutoCRUD/templates/full-fat/wrapper.tt
@@ -60,7 +60,7 @@
                 [% ELSE %]
                     <select id="cpac_picker" onchange="window.location = document.getElementById(this.id).value">
                       [% FOREACH tpath IN cpac.c.$cpac_db.t.keys.sort %]
-                        [% NEXT IF cpac.c.$cpac_db.$tpath.hidden == 'yes' %]
+                        [% NEXT IF cpac.c.$cpac_db.t.$tpath.hidden == 'yes' %]
                         [% IF cpac.g.site == 'default' %]
                             <option value="[% c.uri_for( c.controller('AutoCRUD::Root').action_for('table'), [cpac_db], tpath ) %]"
                         [% ELSE %]


### PR DESCRIPTION
Hello,

If a source is configured to be hidden, a typo in wrapper.tt will make it show up in the <select> box in the #cpac_header div at the top of a list page.   This patch fixes it.  Thank you for your work on this amazing module!

Cheers,
Fitz Elliott
