### PR TITLE
extjs from the CDN over HTTPS

### DIFF
--- a/lib/Catalyst/Plugin/AutoCRUD/templates/extjs2/wrapper/head.tt
+++ b/lib/Catalyst/Plugin/AutoCRUD/templates/extjs2/wrapper/head.tt
@@ -4,7 +4,13 @@
 <meta http-equiv="Content-Type" content="text/html; charset=[% cpac.g.html_charset OR 'utf-8' | html %]" />
 <title>[% cpac.g.title %][% ' - Powered by ' IF cpac.g.title %][% cpac.g.version %]</title>
 
-[% SET extjs_base_uri = cpac.g.extjs2 OR 'http://extjs.cachefly.net/ext-2.2' %]
+[%
+    SET extjs_base_uri = cpac.g.extjs2 OR (
+        c.req.secure
+            ? 'https://extjs.cachefly.net/ext-2.2'
+            : 'http://extjs.cachefly.net/ext-2.2'
+    )
+%]
 
 <link rel="stylesheet" type="text/css" href="[% extjs_base_uri %]/resources/css/ext-all.css" />
 

--- a/t/13-extjs-cachefly.t
+++ b/t/13-extjs-cachefly.t
@@ -18,5 +18,19 @@ $mech->content_contains('Hello, World!', 'Hello World page content');
 $mech->content_contains('http://extjs.cachefly.net/',
     "pages are using the ExtJS CacheFly links");
 
+# mimic that the webserver is running behind a reverse proxy that proxies from
+# HTTPS to HTTP
+$mech->default_header('X-Forwarded-For' => '127.0.0.1');
+$mech->default_header('X-Forwarded-Host' => 'localhost');
+$mech->default_header('X-Forwarded-Port' => 443);
+
+# get basic template, no Metadata
+$mech->get_ok('/autocrud/helloworld', 'Get Hello World page (HTTPS)');
+is($mech->ct, 'text/html', 'Hello World page content type (HTTPS)');
+$mech->content_contains('Hello, World!', 'Hello World page content (HTTPS)');
+
+$mech->content_contains('https://extjs.cachefly.net/',
+    "pages are using the ExtJS CacheFly links (HTTPS)");
+
 # warn $mech->content;
 __END__


### PR DESCRIPTION
Hi,

it seems that extjs.cachefly.net also works over HTTPS, and so using extjs2 from there is also an option - actually could be the default option - even when serving the page over HTTPS.

norbi
