### PR TITLE
JavaScript truncates some valid bigint values

### DIFF
--- a/lib/SQL/Translator/Filter/AutoCRUD/ExtJSxType.pm
+++ b/lib/SQL/Translator/Filter/AutoCRUD/ExtJSxType.pm
@@ -10,9 +10,12 @@ my %xtype_for = (
     boolean => 'checkbox',
 );
 
-$xtype_for{$_} = 'numberfield' for (
+$xtype_for{$_} = 'textfield' for (
     'bigint',
     'bigserial',
+);
+
+$xtype_for{$_} = 'numberfield' for (
     'dec',
     'decimal',
     'double precision',


### PR DESCRIPTION
It is not possible to set some valid bigint values in web-interface because JavaScript validator truncates them. Bigint values in Postgres are 64-bit integers, but JavaScript keeps all numbers as double-precision floating-point numbers, and so is not able to represent the full range of bigint values. When user tries to set via web-interface bigint field to 10000000000000001 it gets changed to 10000000000000000.

Suggested patch removes JavaScript validation for bigint and bigserial fields. On one hand it means that user will be able to enter non digits in bigint input fields and the error will be handled on the server side, but on the other it means that data entered by user won't be changed by JavaScript, which IMO is more important. Of course fixing JavaScript validator would be better, but I'm in no way the person to do this.