### PR TITLE
hide all demo modules from PAUSE

### DIFF
--- a/examples/demo/lib/DemoAppMusicSchema.pm
+++ b/examples/demo/lib/DemoAppMusicSchema.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema;
+package # hide from PAUSE
+    DemoAppMusicSchema;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/Album.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/Album.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::Album;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::Album;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/AlbumArtist.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/AlbumArtist.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::AlbumArtist;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::AlbumArtist;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/Artist.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/Artist.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::Artist;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::Artist;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/Copyright.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/Copyright.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::Copyright;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::Copyright;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/SleeveNote.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/SleeveNote.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::SleeveNote;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::SleeveNote;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppMusicSchema/Result/Track.pm
+++ b/examples/demo/lib/DemoAppMusicSchema/Result/Track.pm
@@ -1,4 +1,5 @@
-package DemoAppMusicSchema::Result::Track;
+package # hide from PAUSE
+    DemoAppMusicSchema::Result::Track;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Artist.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Artist.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Artist;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Artist;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/ArtistUndirectedMap.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/ArtistUndirectedMap.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::ArtistUndirectedMap;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::ArtistUndirectedMap;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/ArtistsCalledMike.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/ArtistsCalledMike.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::ArtistsCalledMike;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::ArtistsCalledMike;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Bookmark.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Bookmark.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Bookmark;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Bookmark;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/BookmarkWithLinkProxy.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/BookmarkWithLinkProxy.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::BookmarkWithLinkProxy;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::BookmarkWithLinkProxy;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Fourkey.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Fourkey.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Fourkey;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Fourkey;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/FourkeysToTwokey.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/FourkeysToTwokey.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::FourkeysToTwokey;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::FourkeysToTwokey;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Link.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Link.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Link;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Link;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Noprimarykey.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Noprimarykey.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Noprimarykey;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Noprimarykey;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/PunctuatedColumnName.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/PunctuatedColumnName.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::PunctuatedColumnName;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::PunctuatedColumnName;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/RefA.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/RefA.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::RefA;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::RefA;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/RefB.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/RefB.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::RefB;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::RefB;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Reference.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Reference.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Reference;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::Reference;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/SelfRef.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/SelfRef.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::SelfRef;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::SelfRef;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/SelfRefAlias.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/SelfRefAlias.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::SelfRefAlias;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::SelfRefAlias;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Twokey.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/Twokey.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::Twokey;
+    DemoAppOtherFeaturesSchema::Result::Twokey;
+package # hide from PAUSE
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/UnicodeTest.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/UnicodeTest.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::UnicodeTest;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::UnicodeTest;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE

--- a/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/VirtualArtistsCalledMike.pm
+++ b/examples/demo/lib/DemoAppOtherFeaturesSchema/Result/VirtualArtistsCalledMike.pm
@@ -1,4 +1,5 @@
-package DemoAppOtherFeaturesSchema::Result::VirtualArtistsCalledMike;
+package # hide from PAUSE
+    DemoAppOtherFeaturesSchema::Result::VirtualArtistsCalledMike;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE


### PR DESCRIPTION
Hello Oliver,

I came across this module and noticed that on https://metacpan.org/release/OLIVER/Catalyst-Plugin-AutoCRUD-2.200002 quite a lot of the modules in the `examples` directory were listed there. Some of them were already hidden though, so I guess you intended to not show any of them.

Cheers